### PR TITLE
FIX : tk8055 : numéro de version sur les pages autres que 1 sur le pdf

### DIFF
--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -78,7 +78,7 @@ class ActionsPropalehistory
 		return 0;
 	}
 
-	function pdf_getLinkedObjects($parameters, &$object, &$action, $hookmanager) {
+	function afterPDFCreation($parameters, &$object, &$action, $hookmanager) {
 		global $langs,$db, $user,$conf, $old_propal_ref;
 
 		if(!empty($conf->global->PROPALEHISTORY_SHOW_VERSION_PDF) && !empty($old_propal_ref)) {

--- a/core/modules/modPropalehistory.class.php
+++ b/core/modules/modPropalehistory.class.php
@@ -62,7 +62,7 @@ class modPropalehistory extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Gestion de l'historique des propositions commerciales";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '1.3.2';
+        $this->version = '1.3.3';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);


### PR DESCRIPTION
L'ancien hook est appelé à chaque page, du coup le numéro de version de la propal ne s'affiche sur les pages > page 1