### PR TITLE
NEW: implementation of hook that helps build sound file paths containing the object's ref

### DIFF
--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -232,5 +232,22 @@ class ActionsPropalehistory
 		}
 	}
 
+	/**
+	 * Enables modules that use $object->ref to build a file path to get the original ref (without the trailing /[DIGITS])
+	 *
+	 * @param array        $parameters
+	 * @param CommonObject $object  The object that holds the ref which PropaleHistory has modified
+	 * @param string       $action
+	 * @param HookManager  $hookmanager
+	 * @return int
+	 */
+	function overrideRefForFileName($parameters, &$object, &$action, $hookmanager) {
+		$ref = $object->ref;
+		// if $ref ends with a forward slash followed by at least one digit, remove everything after (and including) the forward slash
+		/* $ref = preg_replace('#/\d+$#', '', $ref); */
 
+		// override default
+		$this->resprints = $object->context['propale_history']['original_ref'];
+		return 1;
+	}
 }

--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -242,12 +242,13 @@ class ActionsPropalehistory
 	 * @return int
 	 */
 	function overrideRefForFileName($parameters, &$object, &$action, $hookmanager) {
-		$ref = $object->ref;
-		// if $ref ends with a forward slash followed by at least one digit, remove everything after (and including) the forward slash
-		/* $ref = preg_replace('#/\d+$#', '', $ref); */
-
-		// override default
-		$this->resprints = $object->context['propale_history']['original_ref'];
-		return 1;
+		if (!isset($object->context['propale_history']['original_ref'])) {
+			// the specified proposal doesn't have any history entries in llx_propale_history so we don't override ref
+			return 0;
+		} else {
+			// override default
+			$this->resprints = $object->context['propale_history']['original_ref'];
+			return 1;
+		}
 	}
 }


### PR DESCRIPTION
Propalehistory appends a suffix to an object's ref ("/" + number), which sometimes messes with modules that create PDF paths using the ref.

The new hooks, when called by other modules, enables them to get the ref without this suffix.