### PR TITLE
FIX: Trigger class doesn't extend DolibarrTriggers

### DIFF
--- a/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
+++ b/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
@@ -33,11 +33,8 @@
 /**
  * Trigger class
  */
-class InterfacePropalehistory
+class InterfacePropalehistory extends DolibarrTriggers
 {
-
-    private $db;
-
     /**
      * Constructor
      *
@@ -99,7 +96,7 @@ class InterfacePropalehistory
 
     /**
      * Function called when a Dolibarrr business event is done.
-     * All functions "run_trigger" are triggered if file
+     * All functions "runTrigger" are triggered if file
      * is inside directory core/triggers
      *
      * 	@param		string		$action		Event action code
@@ -110,24 +107,6 @@ class InterfacePropalehistory
      * 	@return		int						<0 if KO, 0 if no triggered ran, >0 if OK
      */
     public function runTrigger($action, $object, $user, $langs, $conf)
-    {
-        return $this->run_trigger($action, $object, $user, $langs, $conf);
-    }
-
-
-    /**
-     * Function called when a Dolibarrr business event is done.
-     * All functions "run_trigger" are triggered if file
-     * is inside directory core/triggers
-     *
-     * 	@param		string		$action		Event action code
-     * 	@param		Object		$object		Object
-     * 	@param		User		$user		Object user
-     * 	@param		Translate	$langs		Object langs
-     * 	@param		conf		$conf		Object conf
-     * 	@return		int						<0 if KO, 0 if no triggered ran, >0 if OK
-     */
-    public function run_trigger($action, $object, $user, $langs, $conf)
     {
     	global $conf, $user, $db;
         // Put here code you want to execute when a Dolibarr business events occurs.
@@ -141,17 +120,17 @@ class InterfacePropalehistory
 			dol_include_once("/propalehistory/config.php");
 			dol_include_once("/comm/propal/class/propal.class.php");
 			dol_include_once('/propalehistory/class/propaleHist.class.php');
-	
+
 			if(isset($_REQUEST['mesg'])) {
-			
+
 				setEventMessage($_REQUEST['mesg']);
-	
+
 			}
-			
+
 			$ATMdb = new TPDOdb;
-			
+
 			TPropaleHist::archiverPropale($ATMdb, $object);
-			
+
             dol_syslog(
                 "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
             );


### PR DESCRIPTION
# FIX
- Change the subtotal module trigger class definition to avoid error message from Dolibarr
- Rename `run_trigger` to `runTrigger`
- Remove the declaration of the `$db` field if present (already declared as `protected` in the parent class)