### PR TITLE
FIX : Suppression de conf PROPALEHISTORY_USE_COMPRESS_ARCHIVE

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 2.0
 
+- FIX: Suppression de conf pour ajouter son comportement par défaut - 2.0.3 - *04/04/2020*
 - FIX: token  - 2.0.2 - *16/03/2022*
 - FIX: v14 compatibility - setDateLivraison -> setDeliveryDate - 2.0.1 - *27/07/2021*
 - NEW: compatible with Dolibarr v13 and v14, **no longer compatible with v11 and lower** - *2021-06-28* - 2.0.0

--- a/admin/propalehistory_setup.php
+++ b/admin/propalehistory_setup.php
@@ -178,20 +178,6 @@ if($ok) {
 	print '</td></tr>';
 	
 	
-	$var=!$var;
-	print '<tr '.$bc[$var].'>';
-	print '<td>'.$langs->trans("PROPALEHISTORY_USE_COMPRESS_ARCHIVE").'</td>';
-	print '<td align="center" width="20">&nbsp;</td>';
-	print '<td align="right" width="300">';
-	print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
-	print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
-	print '<input type="hidden" name="action" value="set_PROPALEHISTORY_USE_COMPRESS_ARCHIVE">';
-	print $form->selectyesno("PROPALEHISTORY_USE_COMPRESS_ARCHIVE",$conf->global->PROPALEHISTORY_USE_COMPRESS_ARCHIVE,1);
-	print '<input type="submit" class="button" value="'.$langs->trans("Modify").'">';
-	print '</form>';
-	print '</td></tr>';
-	
-	
 } else {
 	print $langs->trans('ModuleNeedProposalOrOrderModule');
 }

--- a/class/propaleHist.class.php
+++ b/class/propaleHist.class.php
@@ -29,11 +29,7 @@
 		public function setObject(&$object) {
 			global $conf;
 
-			$code =  serialize($object);
-
-			if(!empty($conf->global->PROPALEHISTORY_USE_COMPRESS_ARCHIVE)) {
-				$code = base64_encode( gzdeflate($code) );
-			}
+			$code = base64_encode(gzdeflate(serialize($object)));
 
 			$this->serialized_parent_propale = $code;
 

--- a/core/modules/modPropalehistory.class.php
+++ b/core/modules/modPropalehistory.class.php
@@ -63,7 +63,7 @@ class modPropalehistory extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Gestion de l'historique des propositions commerciales";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.0.2';
+        $this->version = '2.0.3';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/langs/de_DE/propalehistory.lang
+++ b/langs/de_DE/propalehistory.lang
@@ -21,7 +21,6 @@ PropalHistoryAutoArchiveAndArchiveOnModifyCantBeUsedBoth = Versionierung bei Gen
 
 PROPALEHISTORY_ARCHIVE_PDF_TOO = Versionierung für PDF Dateien
 PROPALEHISTORY_HIDE_VERSION_ON_TABS = Versionsnummer im Tab nicht anzeigen
-PROPALEHISTORY_USE_COMPRESS_ARCHIVE = Versionsverlauf komprimieren
 
 ReturnInitialVersion = Zur aktuellen Version zurück
 PropaleHistoryArchiver = Versionieren

--- a/langs/en_US/propalehistory.lang
+++ b/langs/en_US/propalehistory.lang
@@ -20,7 +20,6 @@ PropalHistoryAutoArchiveAndArchiveOnModifyCantBeUsedBoth=Archiving at validation
 
 PROPALEHISTORY_ARCHIVE_PDF_TOO=Archive the PDF too
 PROPALEHISTORY_HIDE_VERSION_ON_TABS=Hide version number in tabs
-PROPALEHISTORY_USE_COMPRESS_ARCHIVE = Compress archival data
 
 ReturnInitialVersion=Return initial version
 PropaleHistoryArchiver=Archive

--- a/langs/fr_FR/propalehistory.lang
+++ b/langs/fr_FR/propalehistory.lang
@@ -27,4 +27,3 @@ Visualiser = Visualiser
 Restaurer = Restaurer
 VersionNumberShort = Version n°
 
-PROPALEHISTORY_USE_COMPRESS_ARCHIVE = Compression des données en base


### PR DESCRIPTION
## FIX : Suppression de conf 

( Vu avec John)
Suppression de la conf PROPALEHISTORY_USE_COMPRESS_ARCHIVE qui aurait du être utilisé par défaut :
- Suppression de la conf dans le fichier de configuration 
- Suppression de son utilisation dans le code 
- Suppression de ses traductions 