### PR TITLE
NEW keep version number on restore

### DIFF
--- a/admin/propalehistory_setup.php
+++ b/admin/propalehistory_setup.php
@@ -75,6 +75,9 @@ $formSetup->newItem('EXPERIMENTAL_OPTIONS')->setAsTitle();
 // Reset des dates des devis sur lors de l'archivage à la date du jour
 $formSetup->newItem('PROPALEHISTORY_ARCHIVE_AND_RESET_DATES')->setAsYesNo();
 
+// keep version number on restoring
+$formSetup->newItem('PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM')->setAsYesNo();
+
 /*
  * Actions
  */

--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -238,9 +238,20 @@ class ActionsPropalehistory
 		} elseif($actionATM == 'restaurer') {
             if (!empty($conf->global->PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM)) {
                 $versionNumSelected = GETPOST('versionNum', 'int');
+
+                // save current proposal version before restoring
+                $currentProposal = new Propal($db);
+                $currentProposal->fetch($object->id);
+                $result = TPropaleHist::archiverPropale($ATMdb, $currentProposal);
+                if ($result < 0) {
+                    setEventMessages($currentProposal->error, $object->errors, 'errors');
+                    header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+                    exit();
+                }
             } else {
                 $versionNumSelected = 0;
             }
+
 			TPropaleHist::restaurerPropale($ATMdb, $object, $versionNumSelected);
 		} elseif($actionATM == 'supprimer') {
 

--- a/core/modules/modPropalehistory.class.php
+++ b/core/modules/modPropalehistory.class.php
@@ -207,6 +207,12 @@ class modPropalehistory extends DolibarrModules
 		$o=new TPropaleHist;
 		$o->init_db_by_vars($PDOdb);
 
+        // Create extrafields
+        include_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
+        $extrafields = new ExtraFields($this->db);
+        // proposal version
+        $result = $extrafields->addExtraField('propalehistory_version_num', 'PropaleHistoryVersionNum', 'int', 1000, '', 'propal', 0, 0, '', '', 0, '', '-4', '', '', 0, 'propalehistory@propalehistory', '$conf->propalehistory->enabled', 0);
+
         return $this->_init($sql, $options);
     }
 

--- a/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
+++ b/core/triggers/interface_99_modPropalehistory_propalehistory.class.php
@@ -115,6 +115,7 @@ class InterfacePropalehistory extends DolibarrTriggers
         $db=&$this->db;
 		//echo $action.'<br>';
         if ($action == 'PROPAL_VALIDATE' && $conf->global->PROPALEHISTORY_AUTO_ARCHIVE) {
+            dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 
 			define('INC_FROM_DOLIBARR', true);
 			dol_include_once("/propalehistory/config.php");
@@ -129,11 +130,15 @@ class InterfacePropalehistory extends DolibarrTriggers
 
 			$ATMdb = new TPDOdb;
 
-			TPropaleHist::archiverPropale($ATMdb, $object);
-
-            dol_syslog(
-                "Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id
-            );
+            /**
+             * @var Propal $object
+             */
+			$result = TPropaleHist::archiverPropale($ATMdb, $object);
+            if ($result < 0) {
+                return -1;
+            } else {
+                return 1;
+            }
         } elseif ($action == 'PROPAL_DELETE') {
             dol_syslog("Trigger '" . $this->name . "' for action '$action' launched by " . __FILE__ . ". id=" . $object->id);
 

--- a/langs/en_US/propalehistory.lang
+++ b/langs/en_US/propalehistory.lang
@@ -21,6 +21,7 @@ PROPALEHISTORY_HIDE_VERSION_ON_TABS = Hide version number in tabs
 PROPALEHISTORY_HIDE_VERSION_ON_TABS_DESC = Hide version number on tabs
 PROPALEHISTORY_SHOW_VERSION_PDF = Show the version number on the PDF (from 2nd version upward)
 PROPALEHISTORY_SHOW_VERSION_PDF_DESC = Display version number on the PDF (from the 2nd version)
+PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Keep version number on restoring
 
 PropaleHistoryArchiver = Archive
 PropalHistoryAutoArchiveAndArchiveOnModifyCantBeUsedBoth = Archiving at validation and modification can not be used at the same time.
@@ -30,3 +31,4 @@ ReturnInitialVersion = Return initial version
 
 VersionNumberShort = Version No.
 Visualiser = Show
+PropaleHistoryVersionNum = Version number

--- a/langs/fr_FR/propalehistory.lang
+++ b/langs/fr_FR/propalehistory.lang
@@ -23,6 +23,7 @@ PROPALEHISTORY_HIDE_VERSION_ON_TABS_DESC = Masquer le numéro de version dans le
 PROPALEHISTORY_SHOW_VERSION_PDF = Afficher le numéro de version sur le PDF (à partir de la 2e)
 PROPALEHISTORY_SHOW_VERSION_PDF_DESC = Afficher le numéro de version sur le PDF (à partir de la 2e)
 PROPALEHISTORY_ARCHIVE_AND_RESET_DATES = Reset des dates des devis à la date du jour lors de l'archivage
+PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Restaurer une proposistion commerciale en gardant le numéro de version
 EXPERIMENTAL_OPTIONS = Options expérimentales
 
 PropaleHistoryArchiver = Archiver
@@ -33,3 +34,4 @@ ReturnInitialVersion = Retour version courante
 
 VersionNumberShort = Version n°
 Visualiser = Visualiser
+PropaleHistoryVersionNum = Numéro de version

--- a/langs/fr_FR/propalehistory.lang
+++ b/langs/fr_FR/propalehistory.lang
@@ -23,7 +23,7 @@ PROPALEHISTORY_HIDE_VERSION_ON_TABS_DESC = Masquer le numéro de version dans le
 PROPALEHISTORY_SHOW_VERSION_PDF = Afficher le numéro de version sur le PDF (à partir de la 2e)
 PROPALEHISTORY_SHOW_VERSION_PDF_DESC = Afficher le numéro de version sur le PDF (à partir de la 2e)
 PROPALEHISTORY_ARCHIVE_AND_RESET_DATES = Reset des dates des devis à la date du jour lors de l'archivage
-PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Restaurer une proposistion commerciale en gardant le numéro de version
+PROPALEHISTORY_RESTORE_KEEP_VERSION_NUM = Restaurer une proposition commerciale en gardant le numéro de version
 EXPERIMENTAL_OPTIONS = Options expérimentales
 
 PropaleHistoryArchiver = Archiver


### PR DESCRIPTION
NEW keep version number on restore

- un nouveau paramètre permettant de restaurer une proposition commerciale tout en gardant le numéro de version
![image](https://user-images.githubusercontent.com/45359511/182880333-4a486bb5-9067-446e-af5d-8d2cfc1eebed.png)

Ajout d'un champ complémentaite caché pour savoir sur quelle version on est.
On garde le même fonctionnement qu'avant lorsque cette option n'est pas activée.

Lorsque cette option est activée : 
- on garde le même comportement lorsqu'on archive une version (ex : si on est sur la version 1 et qu'on archive alors on passe au numéro de version suivante)
- lorsqu'on restaure une version alors on garde son numéro au lieu de restaurer sur la version courante
- par contre lorsqu'on supprime une version alors on ne bouche pas les trous pour pouvoir se repérer avec les numéros de version
