### PR TITLE
FIX linked files were not seen on some cases

### DIFF
--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -128,7 +128,7 @@ class ActionsPropalehistory
 		if (in_array('propalcard', explode(':', $parameters['context'])))
 		{
 			// hack pour remettre la bonne ref pour le bloc showdocuments
-			if ($action == 'builddoc' && !empty($object->ref_old)) $object->ref = $object->ref_old;
+			if (!empty($object->ref_old)) $object->ref = $object->ref_old;
 		}
 	}
 
@@ -187,6 +187,9 @@ class ActionsPropalehistory
 				// New version if wanted
 				$archive_proposal = GETPOST('archive_proposal', 'alpha');
 				if ($archive_proposal == 'on') {
+					// hack pour stocker la bonne ref pour pouvoir la remettre avant le bloc showdocuments
+					$object->ref_old = $object->ref;
+
 					$result = TPropaleHist::archiverPropale($ATMdb, $object);
                     if ($result < 0) {
                         setEventMessages($object->error, $object->errors, 'errors');
@@ -273,7 +276,7 @@ class ActionsPropalehistory
              */
 		}
 
-		if (in_array('propalcard', explode(':', $parameters['context'])) && $action == 'builddoc')
+		if (in_array('propalcard', explode(':', $parameters['context'])))
 		{
 			// hack pour stocker la bonne ref pour pouvoir la remettre avant le bloc showdocuments
 			$object->ref_old = $object->ref;


### PR DESCRIPTION
On  some cases, the files are not showed on propal card. This is due to $object->ref ending with `/<version>`:
- right after modifying a propal and created a new version
- right after saving a modification on a line on a version > 1

![Capture d’écran_2023-03-28_16-21-11](https://user-images.githubusercontent.com/89838020/228277167-753361e7-ecd1-41bc-8496-6f1a67920c2a.png)

This PR fixes this behavior.
It uses the hack that is already been used to fix this, but in a more general way
