### PR TITLE
FIX show documents on validate proposal

### DIFF
--- a/class/actions_propalehistory.class.php
+++ b/class/actions_propalehistory.class.php
@@ -125,9 +125,10 @@ class ActionsPropalehistory
 
 	function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager)
 	{
-		if (in_array('propalcard', explode(':', $parameters['context'])))
+		if (in_array('propalcard', explode(':', $parameters['context'])) && $action != 'confirm_validate')
 		{
 			// hack pour remettre la bonne ref pour le bloc showdocuments
+            // on validate proposal object->ref was updated with new ref (automatic numbering) and old ref begins with (PROV)
 			if (!empty($object->ref_old)) $object->ref = $object->ref_old;
 		}
 	}
@@ -276,9 +277,10 @@ class ActionsPropalehistory
              */
 		}
 
-		if (in_array('propalcard', explode(':', $parameters['context'])))
+		if (in_array('propalcard', explode(':', $parameters['context'])) && $action != 'confirm_validate')
 		{
 			// hack pour stocker la bonne ref pour pouvoir la remettre avant le bloc showdocuments
+            // on validate proposal object->ref is still begin with (PROV) and after this hook it will change with a new ref (automatic numbering)
 			$object->ref_old = $object->ref;
 		}
 


### PR DESCRIPTION
FIX show documents on validate proposal
- when you validate proposal, the document auto-generated was not found
![image](https://github.com/Easya-Solutions/dolibarr_module_propalehistory/assets/45359511/d4706048-a3e0-42c6-8791-13fa9644dadf)

The saved ref of proposal wasn't the same as the object ref after the validate function called after the hook "doActions".
When the hook "doActions" is executed, the object begins with "(PROV)", whereas after "validate" the ref is computed and got a new number (automatic numbering). So the restore value or reference is not equal to the saved ref, and the document is not shown (even if the generated file exists).